### PR TITLE
Add Text.Pandoc.SideNoteHTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,27 @@
 > Convert Pandoc Markdown-style footnotes into sidenotes
 
 This is a simple [Pandoc filter] to convert footnotes into a format that can be
-consumed by [Tufte CSS] and [Pandoc Markdown CSS Theme]. On the whole, this
-project weighs in at well under 100 lines of code. Check out
-[SideNote.hs](src/Text/Pandoc/SideNote.hs) if you're curious how it works.
+consumed by [Tufte CSS] and [Pandoc Markdown CSS Theme].
 
-It's used by calling `pandoc --filter pandoc-sidenote`. To see it in action, see
-[Tufte Pandoc CSS], a project which uses it. In particular, take a look at the
-Makefile included in that project.
+As a command line utility, the project may be used by calling `pandoc --filter
+pandoc-sidenote`. To see it in action, see [Tufte Pandoc CSS], a project which
+uses it. In particular, take a look at the Makefile included in that project.
 
-The core functionality is also exposed as a library, which can be called by Haskell
-applications such as Hakyll.
+Further, the core functionality is also exposed as a library, which can be
+called by Haskell applications such as [Hakyll]. It comes in two different
+flavours:
+
+  - [SideNote.hs](src/Text/Pandoc/SideNote.hs): An implementation making use of
+    pandoc's native `Span` constructors. This is what's used in the
+    `pandoc-sidenote` executable.
+
+  - [SideNoteHTML.hs](src/Text/Pandoc/SideNoteHTML.hs): An
+    implementation that converts the footnote directly into HTML,
+    enabling the embedding of arbitrary blocks inside of side and
+    marginnotes.
+
+On the whole, each file weighs in at just about 100 lines of code—check them out
+if you're curious how they work.
 
 ## Dependencies
 
@@ -98,3 +109,4 @@ stack upload .
 [Pandoc filter]: http://pandoc.org/scripting.html#json-filters
 [Tufte Pandoc CSS]: https://github.com/jez/tufte-pandoc-css
 [Pandoc Markdown CSS Theme]: https://github.com/jez/pandoc-markdown-css-theme
+[Hakyll]: https://jaspervdj.be/hakyll/

--- a/package.yaml
+++ b/package.yaml
@@ -7,6 +7,12 @@ author:              Jake Zimmerman
 maintainer:          zimmerman.jake@gmail.com
 copyright:           2016 Jake Zimmerman
 
+flags:
+  html-sidenotes:
+    description: Enable HTML sidenotes
+    default:     False
+    manual:      True
+
 extra-source-files:
 - README.md
 - LICENSE
@@ -29,12 +35,16 @@ ghc-options:
 dependencies:
 - base >= 4.7 && < 5
 - mtl
-- pandoc
 - pandoc-types >= 1.22
 - text
 
 library:
   source-dirs: src
+  exposed-modules: Text.Pandoc.SideNote
+  when:
+    - condition: flag(html-sidenotes)
+      dependencies: pandoc
+      exposed-modules: Text.Pandoc.SideNoteHTML
 
 executables:
   pandoc-sidenote:

--- a/package.yaml
+++ b/package.yaml
@@ -29,6 +29,7 @@ ghc-options:
 dependencies:
 - base >= 4.7 && < 5
 - mtl
+- pandoc
 - pandoc-types >= 1.22
 - text
 

--- a/pandoc-sidenote.cabal
+++ b/pandoc-sidenote.cabal
@@ -30,6 +30,7 @@ source-repository head
 library
   exposed-modules:
       Text.Pandoc.SideNote
+      Text.Pandoc.SideNoteHTML
   other-modules:
       Paths_pandoc_sidenote
   hs-source-dirs:
@@ -38,6 +39,7 @@ library
   build-depends:
       base >=4.7 && <5
     , mtl
+    , pandoc
     , pandoc-types >=1.22
     , text
   default-language: Haskell2010
@@ -52,6 +54,7 @@ executable pandoc-sidenote
   build-depends:
       base >=4.7 && <5
     , mtl
+    , pandoc
     , pandoc-sidenote
     , pandoc-types >=1.22
     , text

--- a/pandoc-sidenote.cabal
+++ b/pandoc-sidenote.cabal
@@ -27,10 +27,14 @@ source-repository head
   type: git
   location: https://github.com/jez/pandoc-sidenote
 
+flag html-sidenotes
+  description: Enable HTML sidenotes
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Text.Pandoc.SideNote
-      Text.Pandoc.SideNoteHTML
   other-modules:
       Paths_pandoc_sidenote
   hs-source-dirs:
@@ -39,10 +43,14 @@ library
   build-depends:
       base >=4.7 && <5
     , mtl
-    , pandoc
     , pandoc-types >=1.22
     , text
   default-language: Haskell2010
+  if flag(html-sidenotes)
+    exposed-modules:
+        Text.Pandoc.SideNoteHTML
+    build-depends:
+        pandoc
 
 executable pandoc-sidenote
   main-is: Main.hs
@@ -54,7 +62,6 @@ executable pandoc-sidenote
   build-depends:
       base >=4.7 && <5
     , mtl
-    , pandoc
     , pandoc-sidenote
     , pandoc-types >=1.22
     , text

--- a/src/Text/Pandoc/SideNoteHTML.hs
+++ b/src/Text/Pandoc/SideNoteHTML.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{- |
+   Module      : Text.Pandoc.SideNoteHTML
+   Description : Convert pandoc footnotes to sidenotes
+   Copyright   : (c) Tony Zorman  2023
+   License     : MIT
+   Maintainer  : Tony Zorman <soliditsallgood@mailbox.org>
+   Stability   : experimental
+   Portability : non-portable
+-}
+module Text.Pandoc.SideNoteHTML (usingSideNotesHTML) where
+
+import Control.Monad.State (State, foldM, get, modify', runState)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Text.Pandoc (runPure, writeHtml5String)
+import Text.Pandoc.Definition (Block (..), Inline (..), Pandoc (..))
+import Text.Pandoc.Options (WriterOptions)
+import Text.Pandoc.Shared (tshow)
+import Text.Pandoc.Walk (walkM)
+
+-- type NoteType :: Type
+data NoteType = Sidenote | Marginnote
+  deriving stock (Show, Eq)
+
+-- type SidenoteState :: Type
+data SidenoteState = SNS
+  { _writer :: !WriterOptions
+  , counter :: !Int
+  }
+
+-- type Sidenote :: Type -> Type
+type Sidenote = State SidenoteState
+
+-- | Like 'Text.Pandoc.SideNote.usingSideNotes', but immediately
+-- pre-render the sidenotes.  This has the advantage that sidenotes may
+-- be wrapped in a @<div>@ (instead of a 'Span'), which allows arbitrary
+-- blocks to be nested in them.  The disadvantage is that one now has to
+-- specify the 'WriterOptions' for the current document, meaning this is
+-- meant to be used as a module and is unlikely to be useful as a
+-- standalone application.
+--
+-- ==== __Example__
+--
+-- Using this function with <https://jaspervdj.be/hakyll/ hakyll> could
+-- look something like the following, defining an equivalent to the
+-- default @pandocCompiler@.
+--
+-- > myPandocCompiler :: Compiler (Item String)
+-- > myPandocCompiler =
+-- >   pandocCompilerWithTransformM
+-- >     defaultHakyllReaderOptions
+-- >     defaultHakyllWriterOptions
+-- >     (usingSideNotesHTML defaultHakyllWriterOptions)
+--
+usingSideNotesHTML :: WriterOptions -> Pandoc -> Pandoc
+usingSideNotesHTML writer (Pandoc meta blocks) =
+  Pandoc meta (walkBlocks (SNS writer 0) blocks)
+ where
+  walkBlocks :: SidenoteState -> [Block] -> [Block]
+  walkBlocks sns = \case
+    []       -> []
+    (b : bs) -> b' <> walkBlocks s' bs
+     where (b', s') = walkM mkSidenote [b] `runState` sns
+
+-- Sidenotes can probably appear in more places; this should be
+-- filled-in at some point.
+mkSidenote :: [Block] -> Sidenote [Block]
+mkSidenote = foldM (\acc b -> (acc <>) <$> single b) []
+ where
+  -- Try to find and render a sidenote in a single block.
+  single :: Block -> Sidenote [Block]
+  single = \case
+    -- Simulate a paragraph by inserting a dummy block; this is needed
+    -- in case two consecutive paragraphs have sidenotes, or a paragraph
+    -- doesn't have one at all.
+    Para inlines         -> (Para [Str ""] :) <$> renderSidenote [] inlines
+    OrderedList attrs bs -> (:[]) . OrderedList attrs <$> traverse mkSidenote bs
+    BulletList        bs -> (:[]) . BulletList        <$> traverse mkSidenote bs
+    block                -> pure [block]
+
+renderSidenote :: [Inline] -> [Inline] -> Sidenote [Block]
+renderSidenote !inlines = \case
+  []           -> pure [plain inlines]
+  Note bs : xs -> do block <- go bs
+                     mappend [plain (commentStart : inlines), block]
+                         <$> renderSidenote [] xs
+  b       : xs -> renderSidenote (b : inlines) xs
+ where
+  go :: [Block] -> Sidenote Block
+  go blocks = do
+    SNS w i <- get <* modify' (\sns -> sns{ counter = 1 + counter sns })
+    let (typ, noteText) = getNoteType (render w blocks)
+    pure . RawBlock "html" $
+      mconcat [ commentEnd     -- See [Note Comment]
+              , label typ i <> input i <> note typ noteText
+              ]
+
+  -- The '{-}' symbol differentiates between margin note and side note.
+  getNoteType :: Text -> (NoteType, Text)
+  getNoteType t
+    | "{-} " `T.isPrefixOf` t = (Marginnote, T.drop 4 t)
+    | otherwise               = (Sidenote  , t)
+
+  render :: WriterOptions -> [Block] -> Text
+  render w bs = case runPure (writeHtml5String w (Pandoc mempty bs)) of
+    Left  err -> error $ "Text.Pandoc.SideNoteHTML.writePandocWith: " ++ show err
+    Right txt -> T.drop 1 (T.dropWhile (/= '\n') txt)
+
+  commentEnd :: T.Text
+  commentEnd   = "-->"
+
+  commentStart :: Inline
+  commentStart = RawInline "html" "<!--"
+
+  plain :: [Inline] -> Block
+  plain = Plain . reverse
+
+label :: NoteType -> Int -> Text
+label nt i = "<label for=\"sn-" <> tshow i <> "\" class=\"margin-toggle" <> sidenoteNumber <> "\">" <> altSymbol <> "</label>"
+ where
+  sidenoteNumber :: Text = case nt of
+    Sidenote   -> " sidenote-number"
+    Marginnote -> ""
+  altSymbol :: Text = case nt of
+    Sidenote   -> ""
+    Marginnote -> "&#8853;"
+
+input :: Int -> Text
+input i = "<input type=\"checkbox\" id=\"sn-" <> tshow i <> "\" class=\"margin-toggle\"/>"
+
+note :: NoteType -> Text -> Text
+note nt body = "<div class=\"" <> T.toLower (tshow nt) <> "\">" <> body <> "</div>"
+
+{- [Note Comment]
+
+This is obviously horrible, but we have to do this in order for the
+block (which is now not an inline element anymore!) immediately before
+the sidenote to be "glued" to the sidenote itself.  In this way, the
+number indicating the sidenote does not have an extra space associated
+to it, which it otherwise would have.
+
+-}

--- a/src/Text/Pandoc/SideNoteHTML.hs
+++ b/src/Text/Pandoc/SideNoteHTML.hs
@@ -14,14 +14,15 @@
 -}
 module Text.Pandoc.SideNoteHTML (usingSideNotesHTML) where
 
-import Control.Monad.State (State, foldM, get, modify', runState)
+import Control.Monad (foldM)
+import Control.Monad.State (State, get, modify', runState)
 import Data.Text (Text)
-import qualified Data.Text as T
 import Text.Pandoc (runPure, writeHtml5String)
 import Text.Pandoc.Definition (Block (..), Inline (..), Pandoc (..))
 import Text.Pandoc.Options (WriterOptions)
 import Text.Pandoc.Shared (tshow)
 import Text.Pandoc.Walk (walkM)
+import qualified Data.Text as T
 
 -- type NoteType :: Type
 data NoteType = Sidenote | Marginnote

--- a/src/Text/Pandoc/SideNoteHTML.hs
+++ b/src/Text/Pandoc/SideNoteHTML.hs
@@ -85,6 +85,7 @@ mkSidenote = foldM (\acc b -> (acc <>) <$> single b) []
     -- in case two consecutive paragraphs have sidenotes, or a paragraph
     -- doesn't have one at all.
     Para inlines         -> (Para [Str ""] :) <$> renderSidenote [] inlines
+    Plain inlines        -> renderSidenote [] inlines
     OrderedList attrs bs -> (:[]) . OrderedList attrs <$> traverse mkSidenote bs
     BulletList        bs -> (:[]) . BulletList        <$> traverse mkSidenote bs
     block                -> pure [block]

--- a/src/Text/Pandoc/SideNoteHTML.hs
+++ b/src/Text/Pandoc/SideNoteHTML.hs
@@ -59,8 +59,14 @@ type Sidenote = State SidenoteState
 --
 usingSideNotesHTML :: WriterOptions -> Pandoc -> Pandoc
 usingSideNotesHTML writer (Pandoc meta blocks) =
-  Pandoc meta (walkBlocks (SNS writer 0) blocks)
+  -- Drop a superfluous paragraph at the start of the document.
+  Pandoc meta . someStart . walkBlocks (SNS writer 0) $ blocks
  where
+  someStart :: [Block] -> [Block]
+  someStart = \case
+    (Para [Str ""] : bs) -> bs
+    bs                   -> bs
+
   walkBlocks :: SidenoteState -> [Block] -> [Block]
   walkBlocks sns = \case
     []       -> []


### PR DESCRIPTION
A new module, which renders sidenotes directly as HTML, allowing the embedding of arbitrary blocks inside them.  I think this is the best overall solution, as it's 100% backwards compatible, yet still exposes this functionality to the user somehow.

The writer issues mentioned by you [here](https://github.com/jez/pandoc-sidenote/issues/4#issuecomment-269744553) are dealt with by not exposing this as a standalone executable, but only as a library (to be used by e.g. Hakyll), and requiring the user to specify their `WriterOption`s upfront.  I've also put the (massive) `pandoc` dependency behind a flag, so only people wanting to use this functionality have to pay that price.

Related: https://github.com/jez/pandoc-sidenote/issues/4

__NOTE__: I've only tested with with GHC 9.2.5 (stackage lts-20.0)

## Commit Summary

### Add Text.Pandoc.SideNoteHTML

A new module that works much like `Text.Pandoc.SideNote`, but immediately converts the notes into HTML.  This allows us to embed arbitrary blocks into the side and marginnotes (not being restricted to spans anymore), but requires that the user specifies their WriterOptions upfront.  As such, the module may only be used as a library.

### cabal: Add html-sidenotes flag

The dependency on pandoc greatly increases the footprint of the library, which may be unwanted by many users.  As such, keep the new Text.Pandoc.SideNoteHTML module behind an aptly name flag, such that this is somewhat contained.