### PR TITLE
Bump dep pandoc-types ~>1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.22.2
+VERSION := 0.22.3
 
 all: pandoc-sidenote-$(VERSION).zip
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,5 +3,5 @@ extra-package-dbs: []
 packages:
 - '.'
 extra-deps:
-- pandoc-types-1.22
+- pandoc-types-1.23
 resolver: lts-18.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,17 +3,17 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-snapshots:
-- original: lts-18.0
-  completed:
-    sha256: c632012da648385b9fa3c29f4e0afd56ead299f1c5528ee789058be410e883c0
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/0.yaml
-    size: 585393
 packages:
-- original:
-    hackage: pandoc-types-1.22
-  completed:
+- completed:
+    hackage: pandoc-types-1.23@sha256:bf5eac74d6b805520bd57a7be12af09370edde1a86ebffa9ff83eb9c9d860041,4140
     pantry-tree:
-      sha256: 28e43150f4bb0d4d880cf92ade20fefcd8705ee95cfe4a1d0bb5efd320982a9d
+      sha256: 26e9cbed29980acc5fe0dcf5c427d9eb414c044f87d2447c36f588fd73b02dca
       size: 737
-    hackage: pandoc-types-1.22@sha256:15512ce011555ee720820f11cac0598317293406da5812337cbb1550d144e3bd,4071
+  original:
+    hackage: pandoc-types-1.23
+snapshots:
+- completed:
+    sha256: c632012da648385b9fa3c29f4e0afd56ead299f1c5528ee789058be410e883c0
+    size: 585393
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/0.yaml
+  original: lts-18.0


### PR DESCRIPTION
For compatibility with pandoc up to v3.1.1.

Builds and works perfectly on MacOS 12.6.3. Should work on other platforms as well but I have not had the opportunity to test.